### PR TITLE
Removing the <3.11 version limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.10,<3.11" # The upper-bound here is just because that is required for PyInstaller.
+python = "^3.10"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.1"


### PR DESCRIPTION
PyInstaller supports Python 3.11 for over a year. We should get rid of this limit, as it prevents installing `verifydump` on any modern system.

https://pyinstaller.org/en/stable/CHANGES.html#id57

After accepting this merge request, I believe you have to make a new release and make it available on PyPI.