### PR TITLE
Added support for both DolphinTool and dolphin-tool

### DIFF
--- a/verifydump/convert.py
+++ b/verifydump/convert.py
@@ -1,7 +1,9 @@
+import functools
 import logging
 import os
 import pathlib
 import re
+import shutil
 import subprocess
 import tempfile
 
@@ -176,10 +178,24 @@ def convert_gdi_to_cue(gdi_file_path: pathlib.Path, cue_file_path: pathlib.Path)
                     cue_file.write("    INDEX 01 00:02:00\n")
 
 
+@functools.cache
+def find_binary(*names):
+    for name in names:
+        fullpath = shutil.which(name)
+        if fullpath:
+            return fullpath
+
+
 def get_sha1hex_for_rvz(rvz_path, show_command_output: bool) -> str:
     with tempfile.TemporaryDirectory() as dolphin_tool_user_folder_name:
         dolphintool_result = subprocess.run(
-            ["DolphinTool", "verify", "-u", dolphin_tool_user_folder_name, "-i", str(rvz_path), "--algorithm=sha1"],
+            [
+                find_binary("DolphinTool", "dolphin-tool"),
+                "verify",
+                "-u", dolphin_tool_user_folder_name,
+                "-i", str(rvz_path),
+                "--algorithm=sha1",
+            ],
             capture_output=True,
             text=True,
         )


### PR DESCRIPTION
On some systems the tool is named `dolphin-tool` instead of `DolphinTool`. This commit will try to find the available name before running it.